### PR TITLE
Remove the deploy/operations dispatch step

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ If it's a tagged version (vX.Y.Z), an action event is dispatched to the Operatio
           registry-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           registry-user: ${{ secrets.REGISTRY_USERNAME }}
           registry-pass: ${{ secrets.REGISTRY_PASSWORD }}
-          ops-repo-token: ${{ secrets.ODYSSEY_OPERATIONS }}
 ```
 
 ### Inputs
@@ -27,10 +26,9 @@ If it's a tagged version (vX.Y.Z), an action event is dispatched to the Operatio
 | `registry-server` | (**required**) Docker registry location/URL |  |
 | `registry-user` | (**required**) Docker registry username for authentication |  |
 | `registry-pass` | (**required**) Docker registry password for authentication |  |
-| `ops-repo-token` | (**required**) Github access token for the Operations repository |  |
 | `backfeed-repo-token` | Github access token for use inside the docker build |  |
 
 ### Outputs
 | Name | Description |
 | --- | --- |
-| `version` | The generated version string, e.g. 'develop' or 'v1.2.3' |
+| `version` | The generated version string, e.g. 'v1.2.3' or 'latest' |

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,6 @@ inputs:
   registry-pass:
     description: "Docker registry password"
     required: true
-  ops-repo-token:
-    description: "Github token to access operations repo"
-    required: true
   backfeed-repo-token:
     description: "Github token to passthrough docker build to access current repo"
     required: false
@@ -63,31 +60,8 @@ runs:
     - name: "Build and push image"
       env:
         IMAGE: ${{ inputs.registry-server }}/${{ inputs.image-name }}
+      shell: bash
       run: |
         docker build --build-arg GITHUB_TOKEN=${{ inputs.backfeed-repo-token }} -f Dockerfile . -t ${IMAGE}:${{ github.sha }} -t ${IMAGE}:${VERSION}
         docker push ${IMAGE}:${{ github.sha }}
         docker push ${IMAGE}:${VERSION}
-      shell: bash
-
-    - uses: ChristopherHX/conditional@3fce4b7a3171a839b482306f9fd3aba0c2112a24
-      name: "Conditional dispatch"
-      with:
-        if: ${{startsWith(github.ref, 'refs/tags/')}}
-        step: |
-          name: Dispatch to Operations
-          uses: peter-evans/repository-dispatch@v1
-          with:
-            token: ${{ inputs.ops-repo-token }}
-            repository: OdysseyMomentumExperience/Operations
-            event-type: make-acc-pr
-            client-payload: '{"name": "${{ inputs.image-name }}", "version": "${{ steps.setvars.outputs.version }}", "actor": "${{ github.event.actor.login }}"}'
-
-    - uses: ChristopherHX/conditional@3fce4b7a3171a839b482306f9fd3aba0c2112a24
-      name: "!Conditional"
-      with:
-        if: ${{startsWith(github.ref, 'refs/tags/') != true}}
-        step: |
-          shell: bash
-          run: |
-            echo "NOT dispatching to operations:"
-            echo '{"name": "${{ inputs.image-name }}", "version": "${{ steps.setvars.outputs.version }}", "actor": "${{ github.event.actor.login }}"}'


### PR DESCRIPTION
Move this back out of this action.

Avoids the ugly conditional step workaround, and allows us creating a
separate deploy job/action.