### PR TITLE
Fix token in npmrc

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,12 +61,12 @@ runs:
         password: ${{ inputs.registry-pass }}
 
     - name: "Github packages authorization"
-      uses: actions/setup-node@v2
-      with:
-        registry-url: 'https://npm.pkg.github.com'
-        scope: '@OdysseyMomentumExperience'
-        token: ${{ inputs.npm-token }}
-
+      shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.npm-token }}
+      run: |
+        echo "@OdysseyMomentumExperience:registry=https://npm.pkg.github.com/" > $HOME/.npmrc
+        echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> $HOME/.npmrc
     - name: "Build and push image"
       env:
         IMAGE: ${{ inputs.registry-server }}/${{ inputs.image-name }}
@@ -75,7 +75,7 @@ runs:
       run: |
         docker build \
           --build-arg GITHUB_TOKEN=${{ inputs.backfeed-repo-token }} \
-          --secret id=npm,src=$NPM_CONFIG_USERCONFIG \
+          --secret id=npm,src=$HOME/.npmrc \
           -t ${IMAGE}:${{ github.sha }} -t ${IMAGE}:${VERSION} \
           -f Dockerfile .
         docker push ${IMAGE}:${{ github.sha }}


### PR DESCRIPTION
Fix the token in the created .npmrc

The setup-node action sets this to ${NODE_AUTH_TOKEN} environment
variable and not the actual token itself.
We need to pass this to docker, so manually create the file now.
